### PR TITLE
minor bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uw-editor",
   "description": "A React Component Library for editing PERF.",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "homepage": "https://uw-editor.netlify.app/",
   "license": "MIT",
   "repository": {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -87,7 +87,8 @@ export default function Editor( props) {
   const id = popperOpen ? 'simple-popper' : undefined;
   
   const incUndoInx = () => {
-    if (onUnsavedData !== null) {
+    if (onUnsavedData != null) {
+      console.log(onUnsavedData)
       if ((undoInx + 1) === lastSaveUndoInx) onUnsavedData(false)
       else if (undoInx === lastSaveUndoInx) onUnsavedData(true)
     }
@@ -96,7 +97,7 @@ export default function Editor( props) {
 
   const decUndoInx = () => {
     if (undoInx>0) {
-      if (onUnsavedData !== null) {
+      if (onUnsavedData != null) {
         if ((undoInx - 1) === lastSaveUndoInx) onUnsavedData(false)
         else if (undoInx === lastSaveUndoInx) onUnsavedData(true)
       }
@@ -155,7 +156,7 @@ export default function Editor( props) {
   };
 
   const canUndo = blockIsEdited || epiteleteHtml?.canUndo(bookCode);
-  const canRedo = epiteleteHtml?.canRedo(bookCode);
+  const canRedo = (!blockIsEdited) && epiteleteHtml?.canRedo(bookCode);
   const canSave = (blockIsEdited || hasUnsavedBlock) && (lastSaveUndoInx !== undoInx)
 
   const handlers = {

--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -88,7 +88,6 @@ export default function Editor( props) {
   
   const incUndoInx = () => {
     if (onUnsavedData != null) {
-      console.log(onUnsavedData)
       if ((undoInx + 1) === lastSaveUndoInx) onUnsavedData(false)
       else if (undoInx === lastSaveUndoInx) onUnsavedData(true)
     }

--- a/src/components/SectionHeading.jsx
+++ b/src/components/SectionHeading.jsx
@@ -11,7 +11,7 @@ export default function SectionHeading({ type: _type, content, show, index, verb
   }, []);
 
   const checkStr = content
-  const matchRes = checkStr.match(/<span class="mark.*chapter-(\d).*"/)
+  const matchRes = checkStr.match(/<span class="mark.*chapter-(\d+).*"/)
   const chNum = matchRes && matchRes[1] || ""
   let type = index && `Chapter ${chNum}`;
   type ||= (_type === "main") ? "Title & Introduction" : _type;


### PR DESCRIPTION
Really small fixes in the code - but these still make a big difference in the end...
- regEx bug in SectionHeading
- improved handling for canRedo
- small mistake when verifying onUnsavedData != null

To verify:
- Issue #30 in QA Fail is now fixed
- When starting to edit a new paragraph, then the Redo button is now disabled (like it must be)