### PR TITLE
Update README npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ yarn add uw-editor
 ```
 Also you will need to add the peer dependencies:
 ```shell
-npm install @mui/material @mui/styles @mui/icons-material  @mui/styled-engine npm:@mui/styled-engine-sc@latest react react-dom translation-helps-rcl
+npm install @mui/material @mui/styles @mui/icons-material @mui/styled-engine@npm:@mui/styled-engine-sc@latest react react-dom translation-helps-rcl
 ```
 OR 
 ```shell


### PR DESCRIPTION
- it took me a while to figure out what was wrong here. I only worked it out by looking in the `yarn.lock` file that the intention is to install `@mui/styled-engine-sc@latest` labelled as the package `@mui/styled-engine`.
- a similar change is probably needed for the yarn install but I can't confirm that.